### PR TITLE
switch to RESIN_DEVICE_UUID as identifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const mqtt = require('mqtt');
 const cloudRegion = process.env.GOOGLE_IOT_REGION;
 const projectId = process.env.GOOGLE_IOT_PROJECT;
 const registryId = process.env.GOOGLE_IOT_REGISTRY;
-const deviceId = process.env.RESIN_DEVICE_NAME_AT_INIT;
+const deviceId = process.env.RESIN_DEVICE_UUID;
 // Private key file that was created the first time start.sh was run.
 const privateKeyFile = '/data/rsa-priv.pem';
 

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ if [ ! -f /data/service.json ]; then
    if [ -z "$GOOGLE_IOT_SERVICE_JSON" ]; then
    	echo "Missing GOOGLE_IOT_SERVICE_JSON environment variable, login to https://dashboard.resin.io/ to create it"
    	exit
-   elif [ -z "$RESIN_DEVICE_NAME_AT_INIT" ]; then
+   elif [ -z "$RESIN_DEVICE_UUID" ]; then
    	echo "No device name supplied, are you running this in ResinOS?"
    	exit
    elif [ -z "$GOOGLE_IOT_PROJECT" ]; then
@@ -40,7 +40,7 @@ if [ ! -f /data/service.json ]; then
    openssl ec -in rsa-ec_private.pem -pubout -out rsa-ec_public.pem
 
    # Register as Google IoT device with the keys created above
-   gcloud iot devices create $RESIN_DEVICE_NAME_AT_INIT \
+   gcloud iot devices create $RESIN_DEVICE_UUID \
          --project=$GOOGLE_IOT_PROJECT \
          --region=$GOOGLE_IOT_REGION \
          --registry=$GOOGLE_IOT_REGISTRY \


### PR DESCRIPTION
This PR switches to using the resin.io UUID as the device name on google iot rather than the device name as that can change and then would create a new device on the google iot side.