### PR TITLE
Remove non-ascii characters from cgp-setup.sh

### DIFF
--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -165,7 +165,7 @@ echo "Created PubSub telemetry topic: $GCP_STATE_TOPIC"
 ##################################
 echo -e "\n*** GCP PubSub: Create test subscription to telemetry topic ***"
 GCP_SUB_TEST="balena-telemetry-test-sub"
-$GCLOUD_COMMIT && gcloud_slow pubsub subscriptions create --topic ​$GCP_TELEMETRY_TOPIC​ $GCP_SUB_TEST
+$GCLOUD_COMMIT && gcloud_slow pubsub subscriptions create --topic $GCP_TELEMETRY_TOPIC $GCP_SUB_TEST
 echo "Created PubSub test subscription: $GCP_SUB_TEST"
 
 ##################################


### PR DESCRIPTION
Running the `cgp-setup.sh` script results in an error because of the (invisible) `<200b>` characters on line 168. The error is:

```
*** GCP PubSub: Create test subscription to telemetry topic ***
ERROR: gcloud crashed (UnicodeEncodeError): 'utf-8' codec can't encode characters in position 1-2: surrogates not allowed
```

This pull request fixes the error.